### PR TITLE
添加 cocodot(中性栏 · 支付宝直充 · 官转不降智 · 可用 LLMprobe 验真)

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,9 @@ Claude 只支持Opus4.6, 可以按次也可以按量.
 
 Gemini3.1 Pro都是按次的, 每次4分钱.
 
+### [cocodot](https://cocodot.co)
+OpenAI 兼容的 AI API 中转,一个 Key 调 Claude / GPT / Gemini / DeepSeek 等,支付宝人民币充值、按量计费。费率公开(开卡 / 充值 / 消费明码),主打不降智——降不降智可用开源工具 [LLMprobe](https://github.com/oncesylvia/LLMprobe) 自行验证(实测 87/100)。海外注册公司运营,余额可转、卡内资金持牌机构托管。接入地址 `https://cocodot.co/api/ai/v1`。
+
 
 ## 不推荐的
 

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Claude 只支持Opus4.6, 可以按次也可以按量.
 Gemini3.1 Pro都是按次的, 每次4分钱.
 
 ### [cocodot](https://cocodot.co)
-OpenAI 兼容的 AI API 中转,一个 Key 调 Claude / GPT / Gemini / DeepSeek 等,支付宝人民币充值、按量计费。费率公开(开卡 / 充值 / 消费明码),主打不降智——降不降智可用开源工具 [LLMprobe](https://github.com/oncesylvia/LLMprobe) 自行验证(实测 87/100)。海外注册公司运营,余额可转、卡内资金持牌机构托管。接入地址 `https://cocodot.co/api/ai/v1`。
+OpenAI 兼容的 AI API 中转,一个 Key 调 Claude / GPT / Gemini / DeepSeek 等,支付宝人民币充值、按量计费。费率公开(开卡 / 充值 / 消费明码),主打不降智——降不降智可用开源工具 [LLMprobe](https://github.com/cocodot2026/LLMprobe) 自行验证(实测 87/100)。海外注册公司运营,余额可转、卡内资金持牌机构托管。接入地址 `https://cocodot.co/api/ai/v1`。
 
 
 ## 不推荐的


### PR DESCRIPTION
按本列表格式补充一条:**cocodot**(https://cocodot.co)——OpenAI/Anthropic 兼容中转,一个 Key 调 Claude/GPT/Gemini/DeepSeek;支付宝人民币直充、按量计费;主打不降智,可用开源工具 LLMprobe 自行验证(实测 87/100)。

利益相关声明:本 PR 由 cocodot 团队提交;无返佣/推广链接,信息均来自官网,欢迎核验调整。